### PR TITLE
Wake - expand documentation on how to use with IP address

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,14 +30,30 @@ func (c *Client) Close() error {
 	return c.p.Close()
 }
 
-// Wake sends a Wake-on-LAN magic packet to a device with the specified
-// network and hardware address.
+// Wake sends a Wake-on-LAN magic packet to an IP address for the specified
+// hardware address.
+//
+// Note that Wake sends an IP packet, and powered-down network devices
+// generally don't listen on IP addresses. In most cases, addr should be the
+// broadcast address of a subnet configured on the VLAN the target machine
+// is connected to (eg. 10.0.0.255/24). This uses the OS' routing table
+// to select an outgoing interface to send an Ethernet broadcast on.
+//
+// However, IPv6 doesn't have subnet-directed broadcasts.
+// The contents of addr are passed to net.Dial, but be aware that sending to
+// multicast addresses like ff02::1 triggers NDP solicitations before sending
+// the packet, which a powered-down device will usually not reply to.
+// Linux seems to refuse to send IPv6 packets at all to Ethernet address
+// ffff.ffff.ffff, not even when explicitly added as a neighbour entry.
+//
+// If there is no IPv4 subnet available on your target VLAN, add a small dummy
+// subnet or use a RawClient for sending raw Ethernet frames.
 func (c *Client) Wake(addr string, target net.HardwareAddr) error {
 	return c.WakePassword(addr, target, nil)
 }
 
-// WakePassword sends a Wake-on-LAN magic packet to a device with the
-// specified network and hardware address, using the specified password.
+// WakePassword sends a Wake-on-LAN magic packet to an IP address for the specified
+// hardware address, using the specified password.
 //
 // The password must be exactly 0 (empty), 4, or 6 bytes in length.
 func (c *Client) WakePassword(addr string, target net.HardwareAddr, password []byte) error {


### PR DESCRIPTION
Hi Matt, as discussed, some more elaborate documentation for `Wake()`. Hope this could save some users some time troubleshooting, it includes some of my findings trying to broadcast on a v6 stack.

I think it could be useful, but let me know if it's too verbose.