### PR TITLE
Elevate password error

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -28,13 +28,13 @@ func TestClientWakePassword(t *testing.T) {
 			name:     "5 bytes password",
 			target:   make(net.HardwareAddr, 6),
 			password: make([]byte, 5),
-			err:      errInvalidPassword,
+			err:      ErrInvalidPassword,
 		},
 		{
 			name:     "7 byte password",
 			target:   make(net.HardwareAddr, 6),
 			password: make([]byte, 7),
-			err:      errInvalidPassword,
+			err:      ErrInvalidPassword,
 		},
 		{
 			name:     "OK, no password",

--- a/rawclient_test.go
+++ b/rawclient_test.go
@@ -30,13 +30,13 @@ func TestRawClientWakePassword(t *testing.T) {
 			name:     "5 bytes password",
 			target:   make(net.HardwareAddr, 6),
 			password: make([]byte, 5),
-			err:      errInvalidPassword,
+			err:      ErrInvalidPassword,
 		},
 		{
 			name:     "7 byte password",
 			target:   make(net.HardwareAddr, 6),
 			password: make([]byte, 7),
-			err:      errInvalidPassword,
+			err:      ErrInvalidPassword,
 		},
 		{
 			name:     "OK, no password",

--- a/wol.go
+++ b/wol.go
@@ -107,11 +107,7 @@ func (p *MagicPacket) UnmarshalBinary(b []byte) error {
 		}
 	}
 
-	// Password must be 0 (empty), 4, or 6 bytes in length
 	pl := len(b[6+(6*16):])
-	if pl != 0 && pl != 4 && pl != 6 {
-		return errInvalidPassword
-	}
 
 	// Allocate a single byte slice for target and password, and
 	// reslice it to store fields
@@ -122,6 +118,11 @@ func (p *MagicPacket) UnmarshalBinary(b []byte) error {
 
 	copy(bb[6:], b[len(b)-pl:])
 	p.Password = bb[6:]
+
+	// Password must be 0 (empty), 4, or 6 bytes in length
+	if pl != 0 && pl != 4 && pl != 6 {
+		return errInvalidPassword
+	}
 
 	return nil
 }

--- a/wol.go
+++ b/wol.go
@@ -15,9 +15,9 @@ const (
 )
 
 var (
-	// errInvalidPassword is returned if a MagicPacket's Password field is
+	// ErrInvalidPassword is returned if a MagicPacket's Password field is
 	// not exactly 0 (empty), 4, or 6 bytes in length.
-	errInvalidPassword = errors.New("invalid password length")
+	ErrInvalidPassword = errors.New("invalid password length")
 
 	// errInvalidSyncStream is returned if a MagicPacket's synchronization
 	// stream is incorrect.
@@ -53,7 +53,7 @@ type MagicPacket struct {
 // If p.Target is not exactly 6 bytes in length, errInvalidTarget is returned.
 //
 // If p.Password is not exactly 0 (empty), 4, or 6 bytes in length,
-// errInvalidPassword is returned.
+// ErrInvalidPassword is returned.
 func (p *MagicPacket) MarshalBinary() ([]byte, error) {
 	// Must be 6 byte ethernet hardware address
 	if len(p.Target) != 6 {
@@ -62,7 +62,7 @@ func (p *MagicPacket) MarshalBinary() ([]byte, error) {
 
 	// Verify password is correct length
 	if pl := len(p.Password); pl != 0 && pl != 4 && pl != 6 {
-		return nil, errInvalidPassword
+		return nil, ErrInvalidPassword
 	}
 
 	//    6 bytes: synchronization stream
@@ -121,7 +121,7 @@ func (p *MagicPacket) UnmarshalBinary(b []byte) error {
 
 	// Password must be 0 (empty), 4, or 6 bytes in length
 	if pl != 0 && pl != 4 && pl != 6 {
-		return errInvalidPassword
+		return ErrInvalidPassword
 	}
 
 	return nil

--- a/wol_test.go
+++ b/wol_test.go
@@ -46,7 +46,7 @@ func TestMagicPacketMarshalBinary(t *testing.T) {
 				Target:   hwEthernet,
 				Password: []byte{0},
 			},
-			err: errInvalidPassword,
+			err: ErrInvalidPassword,
 		},
 		{
 			desc: "length 5 password",
@@ -54,7 +54,7 @@ func TestMagicPacketMarshalBinary(t *testing.T) {
 				Target:   hwEthernet,
 				Password: []byte{0, 1, 2, 3, 4},
 			},
-			err: errInvalidPassword,
+			err: ErrInvalidPassword,
 		},
 		{
 			desc: "length 7 password",
@@ -62,7 +62,7 @@ func TestMagicPacketMarshalBinary(t *testing.T) {
 				Target:   hwEthernet,
 				Password: []byte{0, 1, 2, 3, 4, 5, 6},
 			},
-			err: errInvalidPassword,
+			err: ErrInvalidPassword,
 		},
 		{
 			desc: "OK, no password",
@@ -238,7 +238,7 @@ func TestMagicPacketUnmarshalBinary(t *testing.T) {
 				0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
 				1, 2, 3,
 			},
-			err: errInvalidPassword,
+			err: ErrInvalidPassword,
 		},
 		{
 			desc: "length 5 password",
@@ -264,7 +264,7 @@ func TestMagicPacketUnmarshalBinary(t *testing.T) {
 				0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
 				1, 2, 3, 4, 5,
 			},
-			err: errInvalidPassword,
+			err: ErrInvalidPassword,
 		},
 		{
 			desc: "OK, no password",


### PR DESCRIPTION
* Elevate password error
* Move processing of packet data to before the password error check

This way, a packet that errors with the password length error can still be used even if it is malformed in that way. 